### PR TITLE
Updated attestation description

### DIFF
--- a/data-model/AttestationFramework.asd
+++ b/data-model/AttestationFramework.asd
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <asnx:module xmlns:asnx="urn:ietf:params:xml:ns:asnx"
              name="AttestationFramework"
              tagDefault="explicit">
@@ -9,10 +9,10 @@
  <import name="InformationFramework"
          schemaLocation="InformationFramework.asd"/>
 
- <namedType name="MyAttestation">
+ <namedType name="MyAttestation" type="Attestation">
   <type>
    <sequence>
-    <element name="signedInfo">
+    <element name="signedInfo" type="SignedInfo">
      <type>
       <sequence>
        <element name="version">
@@ -22,24 +22,16 @@
        </element>
        <element name="serialNumber" type="CertificateSerialNumber"/>
        <element name="signature" type="AlgorithmIdentifier"/>
-       <optional>
-        <element name="issuer" type="Name"/>
-       </optional>
-       <optional>
-        <element name="validity" type="Validity"/>
-       </optional>
-       <optional>
-        <element name="subject" type="Name"/>
-       </optional>
-       <optional>
-        <element name="subjectPublicKeyInfo"
+       <element name="issuer" type="Name"/>
+       <element name="validity" type="Validity"/>
+       <element name="subject" type="Name"/>
+       <element name="subjectPublicKeyInfo"
                  type="SubjectPublicKeyInfo"/>
-       </optional>
        <optional>
         <element name="contract">
          <type>
           <sequenceOf>
-           <element name="item" identifier="" type="SmartContract"/>
+           <element name="item" type="SmartContract"/>
           </sequenceOf>
          </type>
         </element>
@@ -49,11 +41,7 @@
          <choice>
           <element name="dataObject">
            <type>
-            <tagged number="0">
-             <type explicit="true">
-              <sequence/>
-             </type>
-            </tagged>
+            <tagged number="0" type="DataObject"/>
            </type>
           </element>
           <element name="extensions">
@@ -75,13 +63,15 @@
 
  <namedType name="SubjectPublicKeyInfo">
   <type>
-   <sequence>
-    <element name="algorithm" type="AlgorithmIdentifier"/>
-    <element name="subjectPublicKey" type="asnx:BIT-STRING"/>
-   </sequence>
+   <choice>
+    <sequence>
+     <element name="algorithm" type="AlgorithmIdentifier"/>
+     <element name="subjectPublicKey" type="asnx:BIT-STRING"/>
+    </sequence>
+    <element name="null" type="asnx:NULL"/>
+   </choice>
   </type>
  </namedType>
 
  <namedType name="SmartContract" type="asnx:INTEGER"/>
-
 </asnx:module>

--- a/data-model/AttestationFramework.asd
+++ b/data-model/AttestationFramework.asd
@@ -31,7 +31,7 @@
         <element name="contract">
          <type>
           <sequenceOf>
-           <element name="item" type="SmartContract"/>
+           <element name="item" identifier="" type="SmartContract"/>
           </sequenceOf>
          </type>
         </element>

--- a/data-model/AttestationFramework.asd
+++ b/data-model/AttestationFramework.asd
@@ -9,10 +9,10 @@
  <import name="InformationFramework"
          schemaLocation="InformationFramework.asd"/>
 
- <namedType name="MyAttestation" type="Attestation">
+ <namedType name="MyAttestation">
   <type>
    <sequence>
-    <element name="signedInfo" type="SignedInfo">
+    <element name="signedInfo">
      <type>
       <sequence>
        <element name="version">

--- a/data-model/AttestationFramework.asd
+++ b/data-model/AttestationFramework.asd
@@ -41,7 +41,7 @@
          <choice>
           <element name="dataObject">
            <type>
-            <tagged number="0" type="DataObject"/>
+            <tagged number="4" type="DataObject"/>
            </type>
           </element>
           <element name="extensions">
@@ -64,12 +64,18 @@
  <namedType name="SubjectPublicKeyInfo">
   <type>
    <choice>
-    <sequence>
-     <element name="algorithm" type="AlgorithmIdentifier"/>
-     <element name="subjectPublicKey" type="asnx:BIT-STRING"/>
-    </sequence>
+    <element name="value" type="SubjectPublicKeyInfoValue"/>
     <element name="null" type="asnx:NULL"/>
    </choice>
+  </type>
+ </namedType>
+
+ <namedType name="SubjectPublicKeyInfoValue">
+  <type>
+   <sequence>
+    <element name="algorithm" type="AlgorithmIdentifier"/>
+    <element name="subjectPublicKey" type="asnx:BIT-STRING"/>
+   </sequence>
   </type>
  </namedType>
 

--- a/data-model/AttestationFramework.asn
+++ b/data-model/AttestationFramework.asn
@@ -13,7 +13,7 @@ IMPORTS
     Name
         FROM InformationFramework;
 
-Attestation { DataObject } ::=  SEQUENCE  {
+MyAttestation { DataObject } ::=  SEQUENCE  {
 
      signedInfo           SignedInfo { DataObject },
      signatureAlgorithm   AlgorithmIdentifier,

--- a/data-model/AttestationFramework.asn
+++ b/data-model/AttestationFramework.asn
@@ -34,13 +34,16 @@ Attestation { DataObject } ::=  SEQUENCE  {
      }
    }
 
-   SubjectPublicKeyInfo  ::=  CHOICE {
-     value   SEQUENCE {
-                algorithm            AlgorithmIdentifier,
-                subjectPublicKey     BIT STRING  
-             },
-     null    NULL
+   SubjectPublicKeyInfo ::= CHOICE {
+     value       SubjectPublicKeyInfoValue,
+     null        NULL 
    }
+        
+   SubjectPublicKeyInfoValue ::= SEQUENCE {
+     algorithm              AlgorithmIdentifier,
+     subjectPublicKey       BIT STRING 
+   }
+
 
    SmartContract ::= INTEGER
 

--- a/data-model/AttestationFramework.asn
+++ b/data-model/AttestationFramework.asn
@@ -2,7 +2,18 @@ AttestationFramework
 
 DEFINITIONS ::=
 BEGIN
-MyAttestation { DataObject } ::=  SEQUENCE  {
+
+IMPORTS
+    AlgorithmIdentifier,
+    Version,
+    CertificateSerialNumber,
+    Validity,
+    Extensions
+        FROM AuthenticationFramework
+    Name
+        FROM InformationFramework;
+
+Attestation { DataObject } ::=  SEQUENCE  {
 
      signedInfo           SignedInfo { DataObject },
      signatureAlgorithm   AlgorithmIdentifier,
@@ -12,20 +23,24 @@ MyAttestation { DataObject } ::=  SEQUENCE  {
      version         [0]  EXPLICIT Version,
      serialNumber         CertificateSerialNumber,
      signature            AlgorithmIdentifier,
-     issuer               Name OPTIONAL,
-     validity             Validity OPTIONAL,
-     subject              Name OPTIONAL,
-     subjectPublicKeyInfo SubjectPublicKeyInfo OPTIONAL,
+     issuer               Name,
+     validity             Validity,
+     subject              Name,
+     subjectPublicKeyInfo SubjectPublicKeyInfo,
      contract             SEQUENCE OF SmartContract OPTIONAL,
      attestsTo            CHOICE {
-         dataObject  [0]      DataObject, -- defined per objectClass
+         dataObject  [4]      DataObject, -- defined per objectClass
          extensions  [3]      EXPLICIT Extensions
      }
    }
 
-   SubjectPublicKeyInfo  ::=  SEQUENCE  {
-     algorithm            AlgorithmIdentifier,
-     subjectPublicKey     BIT STRING  }
+   SubjectPublicKeyInfo  ::=  CHOICE {
+     value   SEQUENCE {
+                algorithm            AlgorithmIdentifier,
+                subjectPublicKey     BIT STRING  
+             },
+     null    NULL
+   }
 
    SmartContract ::= INTEGER
 

--- a/data-model/AuthenticationFramework.asd
+++ b/data-model/AuthenticationFramework.asd
@@ -80,10 +80,8 @@
   <class>
    <valueField name="id" unique="true"
                type="asnx:OBJECT-IDENTIFIER"/>
-   <optional>
-    <valueField name="critical" type="asnx:BOOLEAN"/>
-    <default literalValue="false"/>
-   </optional>
+   <valueField name="critical" type="asnx:BOOLEAN"/>
+   <default literalValue="false"/>
    <typeField name="ExtnType"/>
   </class>
  </namedClass>

--- a/data-model/AuthenticationFramework.asd
+++ b/data-model/AuthenticationFramework.asd
@@ -33,12 +33,18 @@
  <namedType name="Validity">
   <type>
    <choice>
-    <sequence name="value">
-     <element name="notBefore" type="Time"/>
-     <element name="notAfter" type="Time"/>
-    </sequence>
+    <element name="value" type="ValidityValue"/>
     <element name="null" type="asnx:NULL"/>
    </choice>
+  </type>
+ </namedType>
+
+ <namedType name="ValidityValue">
+  <type>
+   <sequence>
+    <element name="notBefore" type="Time"/>
+    <element name="notAfter" type="Time"/>
+   </sequence>
   </type>
  </namedType>
 
@@ -80,8 +86,10 @@
   <class>
    <valueField name="id" unique="true"
                type="asnx:OBJECT-IDENTIFIER"/>
-   <valueField name="critical" type="asnx:BOOLEAN"/>
-   <default literalValue="false"/>
+   <optional>
+    <valueField name="critical" type="asnx:BOOLEAN"/>
+    <default literalValue="false"/>
+   </optional>
    <typeField name="ExtnType"/>
   </class>
  </namedClass>

--- a/data-model/AuthenticationFramework.asd
+++ b/data-model/AuthenticationFramework.asd
@@ -6,24 +6,18 @@
  <namedType name="AlgorithmIdentifier">
   <type>
    <sequence>
-    <element name="algorithm">
-     <type>
-      <fromClass class="ALGORITHM" fieldName="id"/>
-     </type>
-    </element>
+    <element name="algorithm" type="asnx:OBJECT-IDENTIFIER"/>
     <optional>
      <element name="parameters">
       <type>
-       <fromClass class="ALGORITHM" fieldName="Type"/>
+       <anyElement/> <!-- defined by algorithm -->
       </type>
      </element>
     </optional>
    </sequence>
   </type>
  </namedType>
-
- <namedClass name="ALGORITHM" class="ASN-TYPE-IDENTIFIER"/>
-
+ 
  <namedType name="Version">
   <type>
    <namedNumberList>
@@ -38,19 +32,13 @@
 
  <namedType name="Validity">
   <type>
-   <sequence>
-    <element name="notBefore" type="Time"/>
-    <element name="notAfter" type="Time"/>
-   </sequence>
-  </type>
- </namedType>
-
- <namedType name="SubjectPublicKeyInfo">
-  <type>
-   <sequence>
-    <element name="algorithm" type="AlgorithmIdentifier"/>
-    <element name="subjectPublicKey" type="asnx:BIT-STRING"/>
-   </sequence>
+   <choice>
+    <sequence name="value">
+     <element name="notBefore" type="Time"/>
+     <element name="notAfter" type="Time"/>
+    </sequence>
+    <element name="null" type="asnx:NULL"/>
+   </choice>
   </type>
  </namedType>
 
@@ -66,7 +54,7 @@
  <namedType name="Extensions">
   <type>
    <sequenceOf>
-    <element name="item" identifier="" type="Extension"/>
+    <element name="item" type="Extension"/>
    </sequenceOf>
   </type>
  </namedType>

--- a/data-model/AuthenticationFramework.asd
+++ b/data-model/AuthenticationFramework.asd
@@ -10,7 +10,7 @@
     <optional>
      <element name="parameters">
       <type>
-       <anyElement/> <!-- defined by algorithm -->
+       <element name="value"/> <!-- defined by algorithm -->
       </type>
      </element>
     </optional>
@@ -54,7 +54,7 @@
  <namedType name="Extensions">
   <type>
    <sequenceOf>
-    <element name="item" type="Extension"/>
+    <element name="item" identifier="" type="Extension"/>
    </sequenceOf>
   </type>
  </namedType>

--- a/data-model/AuthenticationFramework.asn
+++ b/data-model/AuthenticationFramework.asn
@@ -13,10 +13,13 @@ Version ::= INTEGER { v1(0), v2(1), v3(2) }
 CertificateSerialNumber ::= INTEGER
 
 Validity ::= CHOICE {
-    value   SEQUENCE {
-                notBefore   Time,
-                notAfter    Time}, 
-    null    NULL
+    value       ValidityValue,
+    null        NULL 
+}
+		
+ValidityValue ::= SEQUENCE {
+    notBefore       Time,
+    notAfter        Time 
 }
 
 Time ::= CHOICE {

--- a/data-model/AuthenticationFramework.asn
+++ b/data-model/AuthenticationFramework.asn
@@ -3,25 +3,20 @@ AuthenticationFramework
 DEFINITIONS ::=
 BEGIN
 
-AlgorithmIdentifier ::= SEQUENCE {
-	algorithm   ALGORITHM.&id,
-	parameters  ALGORITHM.&Type	OPTIONAL
+AlgorithmIdentifier ::= SEQUENCE  {
+    algorithm           OBJECT IDENTIFIER,
+    parameters          ANY DEFINED BY algorithm OPTIONAL -- Some validators have a issue with this line
 }
-
-ALGORITHM ::= TYPE-IDENTIFIER
 
 Version ::= INTEGER { v1(0), v2(1), v3(2) }
 
 CertificateSerialNumber ::= INTEGER
 
-Validity ::= SEQUENCE {
-	notBefore	Time,
-	notAfter	Time
-}
-
-SubjectPublicKeyInfo ::= SEQUENCE {
-	algorithm         AlgorithmIdentifier,
-	subjectPublicKey  BIT STRING
+Validity ::= CHOICE {
+    value   SEQUENCE {
+                notBefore   Time,
+                notAfter    Time}, 
+    null    NULL
 }
 
 Time ::= CHOICE {

--- a/data-model/InformationFramework.asd
+++ b/data-model/InformationFramework.asd
@@ -7,6 +7,7 @@
   <type>
    <choice>
     <element name="rdnSequence" type="RDNSequence"/>
+    <element name="null" type="asnx:NULL"/>
    </choice>
   </type>
  </namedType>
@@ -14,7 +15,7 @@
  <namedType name="RDNSequence">
   <type>
    <sequenceOf>
-    <element name="item" identifier=""
+    <element name="item" 
              type="RelativeDistinguishedName"/>
    </sequenceOf>
   </type>
@@ -23,53 +24,27 @@
  <namedType name="RelativeDistinguishedName">
   <type>
    <setOf minSize="1">
-    <element name="item" identifier=""
-             type="AttributeTypeAndDistinguishedValue"/>
+    <element name="item"
+             type="AttributeTypeAndValue"/>
    </setOf>
   </type>
  </namedType>
 
- <namedType name="AttributeTypeAndDistinguishedValue">
+ <namedType name="AttributeTypeAndValue">
   <type>
    <sequence>
-    <element name="type">
-     <type>
-      <constrained>
-       <type>
-        <fromClass class="ATTRIBUTE" fieldName="id"/>
-       </type>
-       <table objectSet="SupportedAttributes"/>
-      </constrained>
-     </type>
-    </element>
-    <element name="value">
-     <type>
-      <constrained>
-       <type>
-        <fromClass class="ATTRIBUTE" fieldName="Type"/>
-       </type>
-       <table objectSet="SupportedAttributes">
-        <restrictBy>type</restrictBy>
-       </table>
-      </constrained>
-     </type>
-    </element>
+    <element name="type" type="AttributeType"/>
+    <element name="value" type="AttributeValue"/>
    </sequence>
   </type>
  </namedType>
 
- <namedObjectSet name="SupportedAttributes" class="ATTRIBUTE">
-  <objectSet>
-   <extension/>
-  </objectSet>
- </namedObjectSet>
+ <namedType name="AttributeType" value="asnx:OBJECT-IDENTIFIER"/>
+ <namedType name="AttributeValue">
+  <type>
+   <anyElement/> <!-- defined by AttributeType -->
+  </type>
+ </namedType>
 
- <namedClass name="ATTRIBUTE">
-  <class>
-   <typeField name="Type"/>
-   <valueField name="id" unique="true"
-               type="asnx:OBJECT-IDENTIFIER"/>
-  </class>
- </namedClass>
 
 </asnx:module>

--- a/data-model/InformationFramework.asd
+++ b/data-model/InformationFramework.asd
@@ -15,7 +15,7 @@
  <namedType name="RDNSequence">
   <type>
    <sequenceOf>
-    <element name="item" 
+    <element name="item" identifier=""
              type="RelativeDistinguishedName"/>
    </sequenceOf>
   </type>
@@ -24,7 +24,7 @@
  <namedType name="RelativeDistinguishedName">
   <type>
    <setOf minSize="1">
-    <element name="item"
+    <element name="item" identifier=""
              type="AttributeTypeAndValue"/>
    </setOf>
   </type>
@@ -42,7 +42,7 @@
  <namedType name="AttributeType" value="asnx:OBJECT-IDENTIFIER"/>
  <namedType name="AttributeValue">
   <type>
-   <anyElement/> <!-- defined by AttributeType -->
+   <element name="value"/> <!-- any as specified by AttributeType -->
   </type>
  </namedType>
 

--- a/data-model/InformationFramework.asn
+++ b/data-model/InformationFramework.asn
@@ -4,27 +4,21 @@ DEFINITIONS ::=
 BEGIN
 
 Name ::= CHOICE {
-	rdnSequence	RDNSequence -- one possibility for now --
+	rdnSequence	RDNSequence, -- one possibility for now --
+	null        NULL
 }
 
 RDNSequence ::= SEQUENCE OF RelativeDistinguishedName
 
-RelativeDistinguishedName ::= SET SIZE (1 .. MAX) OF AttributeTypeAndDistinguishedValue
+   RelativeDistinguishedName ::=
+     SET SIZE (1..MAX) OF AttributeTypeAndValue
 
-AttributeTypeAndDistinguishedValue ::= SEQUENCE {
-	type 					ATTRIBUTE.&id({SupportedAttributes}),
-	value					ATTRIBUTE.&Type({SupportedAttributes}{@type})
-}
+   AttributeTypeAndValue ::= SEQUENCE {
+     type     AttributeType,
+     value    AttributeValue }
 
-SupportedAttributes ATTRIBUTE ::= { ... }
+   AttributeType ::= OBJECT IDENTIFIER
 
--- This information object class is greatly simplified.
-ATTRIBUTE ::= CLASS {
-	&Type,
-	&id OBJECT IDENTIFIER UNIQUE
-}
-WITH SYNTAX {
-	[ WITH SYNTAX			&Type ]
-	ID						&id }
+   AttributeValue ::= ANY -- DEFINED BY AttributeType
 
 END

--- a/data-model/README.md
+++ b/data-model/README.md
@@ -1,0 +1,172 @@
+# Attestation Encoding
+22 June 2020
+
+### Abstract
+We describe how to construct a TokenScript attestation and how this can be expressed as an URI.  
+
+### Status
+v. 0.2
+First draft by Tore Frederiksen based on the discussion of Weiwu Zhang at <https://community.tokenscript.org/t/a-uri-schema-for-attestations/303>.
+Second draft contains further updates based on discussions on <https://community.tokenscript.org>.
+
+
+## Introduction
+This specification builds on top of TokenScript as specified and discussed at <https://www.tokenscript.org>, <https://community.tokenscript.org> and <https://github.com/AlphaWallet/TokenScript>.
+
+This specification builds on top of the TokenScript notion of a `dataObject` as discussed at <https://github.com/AlphaWallet/TokenScript/blob/master/doc/articles/data-object.md>. A `dataObject` is a collection of specific values that define a concrete token based on a definition of variable name and types. However, a `dataObject` itself does not contain any instance information or linking to a specific owner or holder; i.e. some public Ethereum address. To achieve this an attestation is needed. 
+
+An attestation is an object constructed by an Ethereum entity (public/private key pair holder) that attests to a specific TokenScript `dataObject` through some auxiliary information. This auxiliary information can for example be a serial number and version of token-type. 
+The attestation of the object _may_ be to another specific Ethereum entity or it could be claimable by _any_ Ethereum entity (through some other attestation and a smart contract-specific interpretation).
+
+We note that an attestation is non-transferable, but that transferability can sometimes be implicitly achieved by attesting to another attestation, rather than a token. 
+
+We desire an attestation to be expressed as succinctly as possible to thus allow each attestation to be fully expressed by an URI, insuring easier and more cross-compatible usage. 
+
+## Attestation Design 
+### Design motivation
+The design of the attestation URI is motivated by succinctness and thus to avoid it including redundant information or be of low entropy. In particular as URLs and URIs are recommended to be less than 2048 ASCII characters. The overall attestation takes close inspiration from the X.509 certificate specification, RFC-5280, but makes several fields optional, adds a few new ones and changes some formats. 
+
+### Design specification
+Observe that an attestation is expressed by a JSON object based on the following ASN1 code:
+````Asn1
+Attestation-Module DEFINITIONS AUTOMATIC TAGS ::= BEGIN
+Attestation { DataObject } ::=  SEQUENCE  {
+     signedInfo           SignedInfo,
+     signatureAlgorithm   AlgorithmIdentifier, -- Defined in Sec. 4.1.1.2 of RFC 5280
+     signatureValue       BIT STRING  
+}
+
+SignedInfo { DataObject } ::=  SEQUENCE  {
+     version         [0]  EXPLICIT Version,
+     serialNumber         CertificateSerialNumber,
+     signature            AlgorithmIdentifier, -- Defined in Sec. 4.1.1.2 of RFC 5280
+     issuer               Name, -- Almost defined as in Sec. 4.1.2.4 of RFC 2459
+     validity             Validity, -- Almost defined as in Sec. 4.1.2.5 of RFC 5280
+     subject              Name, -- Almost defined as in Sec. 4.1.2.4 of RFC 5280
+     subjectPublicKeyInfo SubjectPublicKeyInfo, -- Almost defined as in Sec. 4.1 of RFC 5280
+     attestsTo            CHOICE {
+         dataObject  [4]      DataObject -- any data object, ticket is an example
+         extensions  [3]      EXPLICIT Extensions 
+     }
+}
+
+SmartContract ::= INTEGER
+
+END
+````
+We discuss the fields of `SignedInfo` in relation to X.509 as described in RFC 5280. Other fields that are the same as described in X.509 will not be reiterated here and we instead refer to RFC 5280 <https://tools.ietf.org/html/rfc5280>.
+
+### Dropped fields
+
+#### issuerUniqueID and subjectUniqueID
+These fields have been removed as they are optional in X.509 and since identification to the issuer is done implicitly based on its public key and since it might not be desired to explicitly identify a subject.
+
+
+### Change of optionality
+We are, for reasons described below, allowing certain fields to be optional. However due to issues with unambiguous encoding and decoding, we don't use the OPTIONAL keyword but instead require these fields, but allow their content to simply be NULL. The fields in question is `issue`, `validity`, `subject` and `subjectPublicKeyInfo`. 
+
+#### validity
+`validity` is defined as in RFC 5280, except that it is also allowed to be NULL. This is because the contract may have an internal mechanism by which time the attestation is no longer valid. e.g. an event ticket is invalidated when the event finishes. If the event date is changed, the smart contract is reconfigured without requiring the attestations to be reissued.
+
+#### subject
+`subject` is defined as in RFC 5280, except that it is also allowed to be NULL here. This is so since the attestation constructor might not be identifiable; as-in describable by key-value pairs. We note however that the attestation is still uniquely defined by its serial number and the public key used to construct it.
+
+#### subjectPublicKeyInfo
+`subjectPublicKeyInfo` is defined as in RFC 5280, except that it also allowed to be NULL here. This is so because an attestation may bind some claims ("facts") to another attestation instead of a public key. 
+
+Consider, for example, a ticket granting attestation. A ticket is granted to anyone who can prove that his email address is `join.smith@gmail.com`. This makes the ticket attestation depend on another X.509 certificate on that email address. In this case, the certificate has the subjectPublicKeyInfo but the attestation doesn't.
+
+
+### Semantically modified fields
+
+#### version
+Let `a` be the of the attestation; expressed as an integer. We assume `a`<16.
+Let `b` be the underlying X.509 certificate which the attention is based on. As of writing, this can be either 1, 2 or 3. We assume `b`<16.
+
+The `version` value of `Attestation` is then defined to be the result of the arithmetic computation (`a`-1)\*16+`b`-1. For example consider that `Attestation` is at version 5 and it is based on X.509 v. 2. Thus `a`=5 and `b`=2 and `version`=65 since (5-1)\*16+2-2=65.
+
+#### issuer
+`issuer` is a sequence of relative distinguished names, in particular this includes the string field `Common Name`. For attestations this will be _mandatory_ and not contain a common name, but instead contain information about the public key used to sign the attestation.  If the `signatureAlgorithm` has OID 1.2.840.10045.4.3.2, then this field will contain the Ethereum address. That is, the string "0x" followed by the 20 hex characters defining the address. If the `signatureAlgorithm` does not have OID 1.2.840.10045.4.3.2, then the field _must_ contain the bitstring representing the public key (encoded in non-human readable ASCII).
+
+#### subjectPublicKeyInfo
+`subjectPublicKeyInfo` contain info about the entity which the attestation is attesting something for; _if_ the field is not NULL. We note it will have the asn.1 format as follows, as specified in RFC 2459:
+````Asn1
+SubjectPublicKeyInfo  ::=  CHOICE {
+    value   SEQUENCE {
+                algorithm            AlgorithmIdentifier,
+                subjectPublicKey     BIT STRING  
+            },
+    null    NULL
+   }
+````
+The `algorithm` field may be left out, in which case it is implicitly assumed to be reflect ECDSA using secp256k1 with SHA256 through OID 1.2.840.10045.4.3.2.
+
+### Added fields
+
+#### dataObject
+This field defines which underlying `dataObject` the attestation references and works with.
+
+## Encoding
+Encoding an attestation consists of first DER-encoding the information defined by the ASN.1 module. The DER-encoding is then base64 encoded, but with certain fields not being encoded and thus instead contain human-readable ASCII information. 
+We compress the encoding by excluding any redundant/recoverable information. This means the public key parameters are excluded and secp256k1 with SHA-256 is assumed by default. 
+
+Besides the encoding of the concrete attestation, the address of the contract at which the attestation will be used must also be included. The address, in its hex form is prepended to the DER-base64 encoding of the compressed attestation using the exclamation point, !, as separator. 
+
+Since we want to use this as an URI/URL we must avoid certain characters with different meaning in URLs which are allowed in base64 encoding. Concretely this means that the addition sign, +, is replaced with the minus sign, -, and that the forward slash, /, is replaced with the underscore, \_, and that the equality sign (used in the end of a base64 encoding) is replaced with the multiplication sign, \*. 
+
+Finally, if ECDSA with SHA256 is used for signing, then we would like the Ethereum public key fingerprint of the signing key to be human recognizable and thus we are mindful of keeping this as a hex encoding. In the same manner we also desire the `dataObject` to be human readable and thus keep this in its ASCII encoding. 
+
+With this in mind we can formalize the steps needed for both encoding and decoding.
+
+### Encoding steps
+Encoding takes as argument the address of a smart contract which the attestation should be encoded towards. 
+The encoding then proceeds as follows:
+
+1. `signatureAlgorithm` is defined in Sec. 4.1.1.2 of RFC 5280. If the algorithm has OID 1.2.840.10045.4.3.2 (ECDSA with SHA256), then remove `signatureAlgorithm`. Curve choice is not possible under OID 1.2.840.10045.4.3.2 and will be assumed to be secp256k1. Similarly for the optional field `algorithm` in `SubjectPublicKeyInfo`.
+
+2. `signature` is defined in Sec. 4.1.2.3 of RFC 5280. It _must_ contain the same value as `signatureAlgortihm` and is thus always removed.
+
+3. The remaining structure is DER encoded. 
+
+4. The DER encoding is then base64 encoded, with the following exceptions:
+* The content of `dataObject` is decoded back into its human readable ASCII representation. It is furthermore moved to the beginning of the encoding (i.e. before the base64 encoding starts) and appended an exclamation point, !. 
+* If the `signatureAlgorithm` has OID 1.2.840.10045.4.3.2 then the data in the `Common Name` field within the `Name` structure of the `issuer` field is decoded back into ASCII (which implicitly is actually a hex encoding, and thus human readable). It is  appended an exclamation point, !, and then moved to be right after the exclamation point ending the `dataObject` encoding. Thus the format of the encoding is now:
+`<dataObject>!0x<fingerprint>!<base64 of DER encoding>`
+
+5. URL sensitive characters of the ASCII representation are escaped using the URL percent encoding approach as specified in RFC 3986 section 2.1.
+
+6. The address of the smart contract which the attestation is being linked to is appended with an exclamation point, !. Finally the address and exclamation point is prepended to the encoding of the attestation.
+
+7. URL sensitive characters of the encoding (specifically the base64 encoded part) are substituted according to the following rules:
+* Addition sign, +, is replaced with the minus sign, -.
+* Forward slash, /, is replaced with the underscore, \_.
+* Equality, =, is replaced with the multiplication sign, \*.
+
+That is, an attestation will look something like the following when the smart contract address is assumed to be 0x34288B5B65D616B746AE, the fingerprint of the public is 0xAB89BBEF99736629DC23, the `dataObject` has the following ASN.1 form:
+````Asn1
+"dataObject":{
+    "match":1,
+    "class":"lounge/lobby",
+    "admission":1
+}
+````
+0x34288B5B65D616B746AE!match=1;class=lounge%2Flobby;admission=1;0xAB89BBEF99736629DC23!CICyyZb8QcHv0k0bDUV3T0W_EVGGMWOwKD_RIpnbFT_cTAiBsZiTXYqH870YYKE6tjwhnis-BbE8hCNfFlTmrRaCM-gg\*\*
+
+
+### Decoding steps
+The decoding proceeds like the encoding steps, but in the reverse order thus yielding and ASN.1 attestation and smart contract address. 
+
+### Signing and Verification
+The signing will happen on the full decoded ASN.1. Thus it will implicitly include the public key (fingerprint) through `Common Name`, but exclude the smart contract address the current encoding is desired to be used for.
+
+Verification of the signature on an attestation is done as follows:
+1. Decode the URI into its ASN.1 format and smart contract address.
+2. If a non-ECDSA public key was used, then it is decoded based on its OID from `signatureAlgorithm` using the data in `Common Name`, and the signature on the ASN.1 attestation (but not the smart contract address) is verified against this key.
+3. If an ECDSA public key was used then let (r, s) be the values defining the signature and proceed as follows:
+* Let Y be the positive square root of r^3+7. I.e. Y=abs(sqrt (r^3+7)) and define the curve points P=(r,Y) and P'=(r,-Y).
+* Compute the public key Q=r^(-1)(s\*P-H(m)\*G) and Q'=r^(-1)(s\*P'-H(m)\*G) where H(m) is the hash digest of the message signed (i.e. the decoded attestation) interpreted as a positive integer and G is the base point of secp256k1, i.e. 
+(In hex) G=04 79BE667E F9DCBBAC 55A06295 CE870B07 029BFCDB 2DCE28D9 59F2815B 16F81798 483ADA77 26A3C465 5DA4FBFC 0E1108A8 FD17B448 A6855419 9C47D08F FB10D4B8.
+(In decimal) G=60007469361611451595808076307103981948066675035911483428688400614800034609601690612527903279981446538331562636035761922566837056280671244382574348564747448. 
+* Verify that either Q or Q' has the same fingerprint as stored in `Common Name` in the `issuer` field. That is, that the last 20 bytes of Keccak-256(Q), interpreted as hex, is the equal to the value in `Common Name` after `0x`.
+
+NOTE: There is a negligible chance (less than 2^(-128)) that it is not possible to restore the public key. This is so small that we don't consider it, however, in case of a malicious signer it is possible to force this event to happen. Still, this will only result in the failure of verification and thus we do not consider this case a problem.

--- a/data-model/attestation.asn
+++ b/data-model/attestation.asn
@@ -8,7 +8,6 @@ IMPORTS
 	Version,
 	CertificateSerialNumber,
 	Validity,
-	SubjectPublicKeyInfo,
 	Extensions
 		FROM AuthenticationFramework
 	Name
@@ -24,20 +23,24 @@ Attestation { DataObject } ::=  SEQUENCE  {
      version         [0]  EXPLICIT Version,
      serialNumber         CertificateSerialNumber,
      signature            AlgorithmIdentifier,
-     issuer               Name OPTIONAL,
-     validity             Validity OPTIONAL,
-     subject              Name OPTIONAL,
-     subjectPublicKeyInfo SubjectPublicKeyInfo OPTIONAL,
+     issuer               Name,
+     validity             Validity,
+     subject              Name,
+     subjectPublicKeyInfo SubjectPublicKeyInfo,
      contract             SEQUENCE OF SmartContract OPTIONAL,
      attestsTo            CHOICE {
-         dataObject  [0]      DataObject, -- defined per objectClass
+         dataObject  [4]      DataObject, -- defined per objectClass
          extensions  [3]      EXPLICIT Extensions
      }
    }
 
-   SubjectPublicKeyInfo  ::=  SEQUENCE  {
-     algorithm            AlgorithmIdentifier,
-     subjectPublicKey     BIT STRING  }
+   SubjectPublicKeyInfo  ::=  CHOICE {
+    value   SEQUENCE {
+   	            algorithm            AlgorithmIdentifier,
+                subjectPublicKey     BIT STRING  
+   	        },
+   	null    NULL
+   }
 
    SmartContract ::= INTEGER
 
@@ -48,25 +51,20 @@ AuthenticationFramework
 DEFINITIONS ::=
 BEGIN
 
-AlgorithmIdentifier ::= SEQUENCE {
-	algorithm   ALGORITHM.&id,
-	parameters  ALGORITHM.&Type	OPTIONAL
+AlgorithmIdentifier ::= SEQUENCE  {
+    algorithm           OBJECT IDENTIFIER,
+    parameters          ANY DEFINED BY algorithm OPTIONAL -- Some validators have a issue with this line
 }
-
-ALGORITHM ::= TYPE-IDENTIFIER
 
 Version ::= INTEGER { v1(0), v2(1), v3(2) }
 
 CertificateSerialNumber ::= INTEGER
 
-Validity ::= SEQUENCE {
-	notBefore	Time,
-	notAfter	Time
-}
-
-SubjectPublicKeyInfo ::= SEQUENCE {
-	algorithm         AlgorithmIdentifier,
-	subjectPublicKey  BIT STRING
+Validity ::= CHOICE {
+    value   SEQUENCE {
+                notBefore   Time,
+                notAfter    Time}, 
+    null    NULL
 }
 
 Time ::= CHOICE {
@@ -105,28 +103,22 @@ DEFINITIONS ::=
 BEGIN
 
 Name ::= CHOICE {
-	rdnSequence	RDNSequence -- one possibility for now --
+	rdnSequence	RDNSequence, -- one possibility for now --
+	null        NULL
 }
 
 RDNSequence ::= SEQUENCE OF RelativeDistinguishedName
 
-RelativeDistinguishedName ::= SET SIZE (1 .. MAX) OF AttributeTypeAndDistinguishedValue
+   RelativeDistinguishedName ::=
+     SET SIZE (1..MAX) OF AttributeTypeAndValue
 
-AttributeTypeAndDistinguishedValue ::= SEQUENCE {
-	type 					ATTRIBUTE.&id({SupportedAttributes}),
-	value					ATTRIBUTE.&Type({SupportedAttributes}{@type})
-}
+   AttributeTypeAndValue ::= SEQUENCE {
+     type     AttributeType,
+     value    AttributeValue }
 
-SupportedAttributes ATTRIBUTE ::= { ... }
+   AttributeType ::= OBJECT IDENTIFIER
 
--- This information object class is greatly simplified.
-ATTRIBUTE ::= CLASS {
-	&Type,
-	&id OBJECT IDENTIFIER UNIQUE
-}
-WITH SYNTAX {
-	[ WITH SYNTAX			&Type ]
-	ID						&id }
+   AttributeValue ::= ANY -- DEFINED BY AttributeType
 
 END
 

--- a/data-model/attestation.asn
+++ b/data-model/attestation.asn
@@ -34,14 +34,15 @@ Attestation { DataObject } ::=  SEQUENCE  {
      }
    }
 
-   SubjectPublicKeyInfo  ::=  CHOICE {
-    value   SEQUENCE {
-   	            algorithm            AlgorithmIdentifier,
-                subjectPublicKey     BIT STRING  
-   	        },
-   	null    NULL
+   SubjectPublicKeyInfo ::= CHOICE {
+     value       SubjectPublicKeyInfoValue,
+     null        NULL 
    }
-
+        
+   SubjectPublicKeyInfoValue ::= SEQUENCE {
+     algorithm              AlgorithmIdentifier,
+     subjectPublicKey       BIT STRING 
+   }
    SmartContract ::= INTEGER
 
 END
@@ -61,10 +62,13 @@ Version ::= INTEGER { v1(0), v2(1), v3(2) }
 CertificateSerialNumber ::= INTEGER
 
 Validity ::= CHOICE {
-    value   SEQUENCE {
-                notBefore   Time,
-                notAfter    Time}, 
-    null    NULL
+    value       ValidityValue,
+    null        NULL 
+}
+    
+ValidityValue ::= SEQUENCE {
+    notBefore       Time,
+    notAfter        Time 
 }
 
 Time ::= CHOICE {

--- a/src/dk/alexandra/stormbird/cheque/Attestation.java
+++ b/src/dk/alexandra/stormbird/cheque/Attestation.java
@@ -1,0 +1,5 @@
+package dk.alexandra.stormbird.cheque;
+
+public class Attestation {
+
+}

--- a/src/dk/alexandra/stormbird/cheque/Redeem.java
+++ b/src/dk/alexandra/stormbird/cheque/Redeem.java
@@ -1,0 +1,5 @@
+package dk.alexandra.stormbird.cheque;
+
+public class Redeem {
+
+}

--- a/xto1/asdxml-to-asn.xsl
+++ b/xto1/asdxml-to-asn.xsl
@@ -22,8 +22,17 @@
 		<xsl:text>BEGIN</xsl:text>
 		<xsl:call-template name="newLine"/>
 		<xsl:call-template name="newLine"/>
-		<xsl:apply-templates select="node()"/>
+		<xsl:if test="import">
+			<xsl:text>IMPORTS</xsl:text><xsl:call-template name="newLine"/>
+			<xsl:apply-templates select="import"/>
+			<xsl:call-template name="newLine"/>
+		</xsl:if>
+		<xsl:apply-templates select="node() except import"/>
 		<xsl:text>END</xsl:text>
+	</xsl:template>
+	<xsl:template match="import">
+		<xsl:value-of select="@name"/><xsl:text> FROM </xsl:text><xsl:value-of select="replace(@schemaLocation,'.asd','')"/>
+		<xsl:call-template name="newLine"/>
 	</xsl:template>
 	<xsl:template match="namedType[type/sequence]">
 		<xsl:choose>

--- a/xto1/asdxml-to-asn.xsl
+++ b/xto1/asdxml-to-asn.xsl
@@ -81,7 +81,7 @@
 			</xsl:for-each><xsl:for-each select="table">({<xsl:value-of select="@objectSet"/>}<xsl:for-each select="restrictBy">{<xsl:value-of select="concat('@',.)"/>}</xsl:for-each>)</xsl:for-each>
 		</xsl:for-each>
 		<xsl:for-each select="type/sequenceOf"> SEQUENCE OF <xsl:value-of select="element/@type"/>
-		</xsl:for-each><xsl:if test="..[self::optional]"><xsl:value-of select="concat(' ',upper-case(local-name(..)))"/></xsl:if>
+		</xsl:for-each><xsl:apply-templates select="type/element[@name='value' and count(@*) = 1 and not(child::*)]"/><xsl:if test="..[self::optional]"><xsl:value-of select="concat(' ',upper-case(local-name(..)))"/></xsl:if>
 	</xsl:template>
 	<xsl:template mode="element" match="element">
 		<xsl:value-of select="substring($vSpaces, 1, 4)"/>
@@ -90,6 +90,9 @@
 	<xsl:template match="element">
 		<xsl:value-of select="substring($vSpaces, 1, 4)"/>
 		<xsl:call-template name="process-element"/><xsl:text>,</xsl:text><xsl:call-template name="newLine"/>
+	</xsl:template>
+	<xsl:template match="element[@name='value' and count(@*) = 1 and not(child::*)]" priority="1">
+		<xsl:text> ANY</xsl:text>
 	</xsl:template>
 	<xsl:template match="element[not(following-sibling::*)]">
 		<xsl:value-of select="substring($vSpaces, 1, 4)"/>

--- a/xto1/asdxml-to-asn.xsl
+++ b/xto1/asdxml-to-asn.xsl
@@ -24,16 +24,29 @@
 		<xsl:call-template name="newLine"/>
 		<xsl:if test="import">
 			<xsl:text>IMPORTS</xsl:text><xsl:call-template name="newLine"/>
-			<xsl:apply-templates select="import"/>
+			<xsl:for-each-group select="import" group-by="@schemaLocation">
+				<xsl:for-each select="current-group()">
+					<xsl:value-of select="@name"/>
+					<xsl:if test="position() != last()">
+						<xsl:text>, </xsl:text>
+					</xsl:if>
+				</xsl:for-each>
+				<xsl:text> FROM </xsl:text><xsl:value-of select="replace(@schemaLocation,'.asd','')"/>
+				<xsl:if test="position() != last()">
+					<xsl:call-template name="newLine"/>
+				</xsl:if>
+			</xsl:for-each-group>
+			<!--xsl:apply-templates select="import"/--><xsl:text>;</xsl:text>
+			<xsl:call-template name="newLine"/>
 			<xsl:call-template name="newLine"/>
 		</xsl:if>
 		<xsl:apply-templates select="node() except import"/>
 		<xsl:text>END</xsl:text>
 	</xsl:template>
-	<xsl:template match="import">
+	<!--xsl:template match="import">
 		<xsl:value-of select="@name"/><xsl:text> FROM </xsl:text><xsl:value-of select="replace(@schemaLocation,'.asd','')"/>
 		<xsl:call-template name="newLine"/>
-	</xsl:template>
+	</xsl:template-->
 	<xsl:template match="namedType[type/sequence]">
 		<xsl:choose>
 			<xsl:when test="lower-case(substring(@name,1,2)) = 'my'"><xsl:value-of select="substring(@name, 3)"/></xsl:when>
@@ -127,7 +140,7 @@
 		</xsl:for-each>
 	</xsl:template>
 	<xsl:template match="element[type/tagged]" priority="99">
-		<xsl:value-of select="substring($vSpaces, 1, (4 * count(ancestor::element)))"/><xsl:value-of select="@name"/><xsl:value-of select="substring($vSpaces, 1, 8)"/>[<xsl:value-of select="type/tagged/@number"/>] <xsl:if test=".[not(@type) and descendant-or-self::element[@name='dataObject']]"> <xsl:value-of select="concat(upper-case(substring(@name,1,1)),substring(@name, 2))"/></xsl:if><xsl:value-of select="string-join((upper-case(type/tagged/@tagging),type/tagged/@type), ' ')"/><xsl:if test="..[not(self::choice or self::sequence)]"><xsl:value-of select="concat(' ', upper-case(local-name(..)))"/></xsl:if><xsl:if test="following-sibling::* or ..[following-sibling::*]">,</xsl:if><xsl:call-template name="newLine"/>
+		<xsl:value-of select="substring($vSpaces, 1, (4 * count(ancestor::element)))"/><xsl:value-of select="@name"/><xsl:value-of select="substring($vSpaces, 1, 8)"/>[<xsl:value-of select="type/tagged/@number"/>] <!--xsl:if test=".[not(@type) and descendant-or-self::element[@name='dataObject']]"> <xsl:value-of select="concat(upper-case(substring(@name,1,1)),substring(@name, 2))"/></xsl:if--><xsl:value-of select="string-join((upper-case(type/tagged/@tagging),type/tagged/@type), ' ')"/><xsl:if test="..[not(self::choice or self::sequence)]"><xsl:value-of select="concat(' ', upper-case(local-name(..)))"/></xsl:if><xsl:if test="following-sibling::* or ..[following-sibling::*]">,</xsl:if><xsl:call-template name="newLine"/>
 	</xsl:template>
 	<xsl:template match="optional[element[type/fromClass]]">
 		<xsl:value-of select="substring($vSpaces, 1, 4)"/>


### PR DESCRIPTION
I have fixed typos and verified syntax using https://asn1.io/asn1playground/Default.aspx 
(with the exception that it comes with one complaint of mixed syntax despite that part being verbatim taken from the RFC)
I have validated XML as well. But I have not been able to verify that it is completely correct since I was unable to find an XSD for the ASNX (ASN1 XML format, RFC 4914 and RFC 4910). 
The main changes on the schema is that OPTIONAL is removed some places since they can result in indeterministic en/decoding.
I have updated syntax to be consistant with the current X509, RFC-5280 and I have added a readme file which is an update of the attestation documentation I wrote in the beginning of the year. 