### PR TITLE
Smaller attestation request

### DIFF
--- a/src/main/java/com/alphawallet/attestation/AttestationRequest.java
+++ b/src/main/java/com/alphawallet/attestation/AttestationRequest.java
@@ -15,7 +15,6 @@ import org.bouncycastle.asn1.ASN1Sequence;
 import org.bouncycastle.asn1.DERBitString;
 import org.bouncycastle.asn1.DERSequence;
 import org.bouncycastle.asn1.DERVisibleString;
-import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
 import org.bouncycastle.crypto.AsymmetricCipherKeyPair;
 import org.bouncycastle.crypto.params.AsymmetricKeyParameter;
 import org.bouncycastle.crypto.util.PublicKeyFactory;
@@ -57,8 +56,7 @@ public class AttestationRequest implements ASNEncodable, Validateable, Verifiabl
           ASN1Integer.getInstance(unsigned.getObjectAt(1)).getValue().intValueExact()];
       this.pok = new ProofOfExponent(
           ASN1Sequence.getInstance(unsigned.getObjectAt(2)).getEncoded());
-      this.publicKey = PublicKeyFactory
-          .createKey(SubjectPublicKeyInfo.getInstance(asn1.getObjectAt(1)));
+      this.publicKey = SignatureUtility.restoreKey(DERBitString.getInstance(asn1.getObjectAt(1)).getEncoded());
       DERBitString signatureEnc = DERBitString.getInstance(asn1.getObjectAt(2));
       this.signature = signatureEnc.getBytes();
     } catch (IOException e) {
@@ -99,7 +97,7 @@ public class AttestationRequest implements ASNEncodable, Validateable, Verifiabl
       byte[] rawData = getUnsignedEncoding();
       ASN1EncodableVector res = new ASN1EncodableVector();
       res.add(ASN1Primitive.fromByteArray(rawData));
-      res.add(SubjectPublicKeyInfoFactory.createSubjectPublicKeyInfo(publicKey));
+      res.add(SubjectPublicKeyInfoFactory.createSubjectPublicKeyInfo(publicKey).getPublicKeyData());
       res.add(new DERBitString(signature));
       return new DERSequence(res).getEncoded();
     } catch (Exception e) {

--- a/src/test/java/com/alphawallet/attestation/TestURL.java
+++ b/src/test/java/com/alphawallet/attestation/TestURL.java
@@ -10,6 +10,9 @@ import com.alphawallet.attestation.cheque.ChequeDecoder;
 import com.alphawallet.attestation.core.AttestationCrypto;
 import com.alphawallet.attestation.core.SignatureUtility;
 import com.alphawallet.attestation.core.URLUtility;
+import com.alphawallet.attestation.ticket.Ticket;
+import com.alphawallet.attestation.ticket.Ticket.TicketClass;
+import com.alphawallet.attestation.ticket.TicketDecoder;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.security.SecureRandom;
@@ -34,7 +37,7 @@ public class TestURL {
   }
 
   @Test
-  public void testSunshine() throws IOException  {
+  public void testChequeSunshine() throws IOException  {
     BigInteger senderSecret = new BigInteger("112");
     Cheque cheque = new Cheque("test@test.ts", AttestationType.EMAIL, 1000, 3600000, senderKeys, senderSecret);
 
@@ -54,12 +57,48 @@ public class TestURL {
   }
 
   @Test
-  public void testConsistentEncoding() throws IOException {
+  public void testChequeConsistentEncoding() throws IOException {
     BigInteger senderSecret = new BigInteger("112");
     Cheque cheque = new Cheque("test@test.ts", AttestationType.EMAIL, 1000, 3600000, senderKeys, senderSecret);
     String url = URLUtility.encodeData(cheque.getDerEncoding());
     Cheque newCheque =  (new ChequeDecoder()).decode(URLUtility.decodeData(url));
     String newUrl = URLUtility.encodeData(newCheque.getDerEncoding());
     assertEquals(url, newUrl);
+  }
+
+  @Test
+  public void testTicketSunshine() throws IOException  {
+    BigInteger ticketID = new BigInteger("417541561854");
+    TicketClass ticketClass = TicketClass.REGULAR;
+    BigInteger senderSecret = new BigInteger("45845870684");
+    Ticket ticket = new Ticket("mah@mah.com", ticketID, ticketClass, 6, senderKeys, senderSecret);
+
+    byte[] senderPublicKey = SubjectPublicKeyInfoFactory.createSubjectPublicKeyInfo(senderKeys.getPublic()).getPublicKeyData().getEncoded();
+    String url = URLUtility.encodeList(Arrays.asList(ticket.getDerEncoding(), senderPublicKey));
+
+    List<byte[]> decoded = URLUtility.decodeList(url);
+    Ticket newTicket = (new TicketDecoder(senderKeys.getPublic())).decode(decoded.get(0));
+    assertTrue(newTicket.verify());
+    assertTrue(newTicket.checkValidity());
+    assertArrayEquals(ticket.getDerEncoding(), newTicket.getDerEncoding());
+
+    AsymmetricKeyParameter newIssuerPublicKey = SignatureUtility.restoreKey(decoded.get(1));
+    Ticket otherConstructorTicket = new Ticket(newTicket.getTicketId(), newTicket.getTicketClass(), newTicket.getConferenceId(),
+        newTicket.getRiddle(), newTicket.getSignature(), newIssuerPublicKey);
+    assertArrayEquals(ticket.getDerEncoding(), otherConstructorTicket.getDerEncoding());
+  }
+
+  @Test
+  public void testTicketConsistentEncoding() throws IOException {
+    BigInteger ticketID = new BigInteger("14840860468475837258758376");
+    TicketClass ticketClass = TicketClass.VIP;
+    BigInteger senderSecret = new BigInteger("186416");
+    Ticket ticket = new Ticket("ticket@test.ts", ticketID, ticketClass, 6, senderKeys, senderSecret);
+    String url = URLUtility.encodeData(ticket.getDerEncoding());
+    Ticket newTicket =  (new TicketDecoder(senderKeys.getPublic())).decode(URLUtility.decodeData(url));
+    String newUrl = URLUtility.encodeData(newTicket.getDerEncoding());
+    assertEquals(url, newUrl);
+    /*** PRINT URL ***/
+    System.out.println(url);
   }
 }


### PR DESCRIPTION
Changed Attestation request to only contain the user's public key instead of the full SPKI (since we always use ECDSA secp256k1).
This was suggested by Oleg to be consistent with what we store in e.g. Cheque and Ticket objects.